### PR TITLE
Fix appveyor build after new nuget version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,12 @@ test_script:
 
     $coverallsPath = Resolve-Path "packages\coveralls.net.*\tools\csmacnz.coveralls.exe"
 
+    echo $coverallsPath
+
+    pwd
+
+    Resolve-Path "packages\coveralls.net.*\tools\csmacnz.coveralls.exe"
+
     $coveralls = $coverallsPath.ToString()
 
     & $coveralls --dynamiccodecoverage `

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ test_script:
     
     Push-AppveyorArtifact MoyaCoverage.coveragexml
 
-    $coverallsPath = Resolve-Path "packages/coveralls.net.*/tools/csmacnz.coveralls.exe"
+    $coverallsPath = Resolve-Path "packages\coveralls.net.*\tools\csmacnz.coveralls.exe"
 
     $coveralls = $coverallsPath.ToString()
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,9 @@ test_script:
     
     Push-AppveyorArtifact MoyaCoverage.coveragexml
 
-    $coveralls = (Resolve-Path "packages/coveralls.net.*/tools/csmacnz.coveralls.exe").ToString()
+    $coverallsPath = Resolve-Path "packages/coveralls.net.*/tools/csmacnz.coveralls.exe"
+
+    $coveralls = $coverallsPath.ToString()
 
     & $coveralls --dynamiccodecoverage `
                  -i MoyaCoverage.coveragexml `

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
     secure: T0CN6Rhd2CAhg368vxiH+RHgJgRzce4xmPu9lH6huFVq3/B58CG1Jl6bOxxk6CI6
 before_build:
   - nuget restore ".\Moya.sln"
-  - nuget install ".\.nuget\packages.config"
+  - nuget install ".\.nuget\packages.config" -OutputDirectory packages
 build:
   project: .\Moya.sln
   verbosity: minimal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,6 +41,10 @@ test_script:
 
     Resolve-Path "packages\coveralls.net.*\tools\csmacnz.coveralls.exe"
 
+    ls
+
+    ls .\packages
+
     $coveralls = $coverallsPath.ToString()
 
     & $coveralls --dynamiccodecoverage `

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,15 +35,7 @@ test_script:
 
     $coverallsPath = Resolve-Path "packages\coveralls.net.*\tools\csmacnz.coveralls.exe"
 
-    echo $coverallsPath
-
-    pwd
-
-    Resolve-Path "packages\coveralls.net.*\tools\csmacnz.coveralls.exe"
-
-    ls
-
-    ls .\packages
+    nuget
 
     $coveralls = $coverallsPath.ToString()
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
     secure: T0CN6Rhd2CAhg368vxiH+RHgJgRzce4xmPu9lH6huFVq3/B58CG1Jl6bOxxk6CI6
 before_build:
   - nuget restore ".\Moya.sln"
+  - nuget install ".\.nuget\packages.config"
 build:
   project: .\Moya.sln
   verbosity: minimal
@@ -34,8 +35,6 @@ test_script:
     Push-AppveyorArtifact MoyaCoverage.coveragexml
 
     $coverallsPath = Resolve-Path "packages\coveralls.net.*\tools\csmacnz.coveralls.exe"
-
-    nuget
 
     $coveralls = $coverallsPath.ToString()
 


### PR DESCRIPTION
Nuget 3.1.0.0 does not install solution-wide packages by default. 
This broke my build: It did not send coverage information to coveralls.io.
Fixed by installing solution-wide packages separately (coveralls.net).

Fixes #2
